### PR TITLE
A minor negation in GetDelay to make it more readable #1419

### DIFF
--- a/src/Moq/ReturnsExtensions.cs
+++ b/src/Moq/ReturnsExtensions.cs
@@ -339,7 +339,7 @@ namespace Moq
 
         static TimeSpan GetDelay(TimeSpan minDelay, TimeSpan maxDelay, Random random)
         {
-            if (!(minDelay < maxDelay))
+            if (minDelay >= maxDelay)
                 throw new ArgumentException(Resources.MinDelayMustBeLessThanMaxDelay);
 
             var min = (int)minDelay.Ticks;


### PR DESCRIPTION
## A minor negation in GetDelay()

As discussed in #1419 this pull request aims to enhance the readability of the `GetDelay()` method by replacing the negation operator `!` with `>=`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have run all unit tests successfully
