### PR TITLE
Minor enhancement to avoid null exceptions

### DIFF
--- a/src/Moq/Async/AwaitableFactory.cs
+++ b/src/Moq/Async/AwaitableFactory.cs
@@ -30,7 +30,7 @@ namespace Moq.Async
                     awaitableType.GetGenericArguments()));
         }
 
-        public static IAwaitableFactory TryGet(Type type)
+        public static IAwaitableFactory? TryGet(Type type)
         {
             Debug.Assert(type != null);
 

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -296,7 +296,7 @@ namespace Moq
                             var memberAccessExpression = (MemberExpression)e;
                             Debug.Assert(memberAccessExpression.Member is PropertyInfo);
 
-                            if (IsResult(memberAccessExpression.Member, out var awaitableFactory))
+                            if (IsResult(memberAccessExpression.Member, out var awaitableFactory) && awaitableFactory is not null)
                             {
                                 Split(memberAccessExpression.Expression, out r, out p);
                                 p.AddResultExpression(
@@ -339,7 +339,7 @@ namespace Moq
                 }
             }
 
-            bool IsResult(MemberInfo member, out IAwaitableFactory awaitableFactory)
+            bool IsResult(MemberInfo member, out IAwaitableFactory? awaitableFactory)
             {
                 var instanceType = member.DeclaringType;
                 awaitableFactory = AwaitableFactory.TryGet(instanceType);


### PR DESCRIPTION
Returning `IAwaitableFactory?` in [AwaitableFactory.cs](https://github.com/devlooped/moq/blob/95c4344ad089d3f4c5a629270f5fdc63480acdb4/src/Moq/Async/AwaitableFactory.cs#L33) file's `TryGet` method, in order to fix #1533.