### PR TITLE
Minimal changes to allow post-execution sequence verification

### DIFF
--- a/src/Moq/IInvocation.cs
+++ b/src/Moq/IInvocation.cs
@@ -41,5 +41,10 @@ namespace Moq
         /// Optional exception if the method invocation results in an exception being thrown.
         /// </summary>
         Exception Exception { get; }
+
+        /// <summary>
+        /// A number representing the order of this invocation in time with respect to all other invocations
+        /// </summary>
+        long SequenceNumber { get; }
     }
 }

--- a/src/Moq/IVerifyResult.cs
+++ b/src/Moq/IVerifyResult.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moq
+{
+    /// <summary>
+    /// A collection of invocations verified by a call to mock.Verify() or one of its variations
+    /// </summary>
+    /// <typeparam name="T">The type being mocked and verified</typeparam>
+    public interface IVerifyResult<T> : IReadOnlyList<IInvocation> where T: class
+    {
+        /// <summary>
+        /// The mock that was verified
+        /// </summary>
+        Mock<T> Mock { get; }
+    }
+}

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
-
+using System.Threading;
 using Moq.Async;
 
 namespace Moq
@@ -20,6 +20,8 @@ namespace Moq
         object result;
         Setup matchingSetup;
         bool verified;
+        long sequenceNumber;
+        static long globalSequenceNumber = 0;//ONLY access with Interlocked.Increment()
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Invocation"/> class.
@@ -36,7 +38,10 @@ namespace Moq
             this.arguments = arguments;
             this.method = method;
             this.proxyType = proxyType;
+            this.sequenceNumber = Interlocked.Increment(ref globalSequenceNumber);
         }
+
+        public long SequenceNumber => this.sequenceNumber;
 
         /// <summary>
         /// Gets the method of the invocation.

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -313,7 +313,7 @@ namespace Moq
             }
         }
 
-        internal static void Verify(Mock mock, LambdaExpression expression, Times times, string failMessage)
+        internal static IEnumerable<IInvocation> Verify(Mock mock, LambdaExpression expression, Times times, string failMessage)
         {
             Guard.NotNull(times, nameof(times));
 
@@ -326,6 +326,7 @@ namespace Moq
                     part.SetupEvaluatedSuccessfully(invocation);
                     invocation.MarkAsVerified();
                 }
+                return invocationsToBeMarkedAsVerified.Select(pair => (IInvocation)pair.Item1);
             }
             else
             {
@@ -333,7 +334,7 @@ namespace Moq
             }
         }
 
-        internal static void VerifyGet(Mock mock, LambdaExpression expression, Times times, string failMessage)
+        internal static IEnumerable<IInvocation> VerifyGet(Mock mock, LambdaExpression expression, Times times, string failMessage)
         {
             Guard.NotNull(expression, nameof(expression));
 
@@ -343,31 +344,31 @@ namespace Moq
                 Guard.CanRead(property);
             }
 
-            Mock.Verify(mock, expression, times, failMessage);
+            return Mock.Verify(mock, expression, times, failMessage);
         }
 
-        internal static void VerifySet(Mock mock, LambdaExpression expression, Times times, string failMessage)
+        internal static IEnumerable<IInvocation> VerifySet(Mock mock, LambdaExpression expression, Times times, string failMessage)
         {
             Guard.NotNull(expression, nameof(expression));
             Guard.IsAssignmentToPropertyOrIndexer(expression, nameof(expression));
 
-            Mock.Verify(mock, expression, times, failMessage);
+            return Mock.Verify(mock, expression, times, failMessage);
         }
 
-        internal static void VerifyAdd(Mock mock, LambdaExpression expression, Times times, string failMessage)
+        internal static IEnumerable<IInvocation> VerifyAdd(Mock mock, LambdaExpression expression, Times times, string failMessage)
         {
             Guard.NotNull(expression, nameof(expression));
             Guard.IsEventAdd(expression, nameof(expression));
 
-            Mock.Verify(mock, expression, times, failMessage);
+            return Mock.Verify(mock, expression, times, failMessage);
         }
 
-        internal static void VerifyRemove(Mock mock, LambdaExpression expression, Times times, string failMessage)
+        internal static IEnumerable<IInvocation> VerifyRemove(Mock mock, LambdaExpression expression, Times times, string failMessage)
         {
             Guard.NotNull(expression, nameof(expression));
             Guard.IsEventRemove(expression, nameof(expression));
 
-            Mock.Verify(mock, expression, times, failMessage);
+            return Mock.Verify(mock, expression, times, failMessage);
         }
 
         internal static void VerifyNoOtherCalls(Mock mock)

--- a/src/Moq/Mock`1.cs
+++ b/src/Moq/Mock`1.cs
@@ -705,9 +705,10 @@ namespace Moq
         ///     mock.Verify(proc => proc.Execute("ping"));
         ///   </code>
         /// </example>
-        public void Verify(Expression<Action<T>> expression)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify(Expression<Action<T>> expression)
         {
-            Mock.Verify(this, expression, Times.AtLeastOnce(), null);
+            return new VerifyResult<T>(this, Mock.Verify(this, expression, Times.AtLeastOnce(), null));
         }
 
         /// <summary>
@@ -719,9 +720,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void Verify(Expression<Action<T>> expression, Times times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify(Expression<Action<T>> expression, Times times)
         {
-            Mock.Verify(this, expression, times, null);
+            return new VerifyResult<T>(this, Mock.Verify(this, expression, times, null));
         }
 
         /// <summary>
@@ -733,9 +735,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void Verify(Expression<Action<T>> expression, Func<Times> times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify(Expression<Action<T>> expression, Func<Times> times)
         {
-            Verify(expression, times());
+            return Verify(expression, times());
         }
 
         /// <summary>
@@ -746,9 +749,10 @@ namespace Moq
         /// <param name="expression">Expression to verify.</param>
         /// <param name="failMessage">Message to show if verification fails.</param>
         /// <exception cref="MockException">The invocation was not performed on the mock.</exception>
-        public void Verify(Expression<Action<T>> expression, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify(Expression<Action<T>> expression, string failMessage)
         {
-            Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
+            return new VerifyResult<T>(this, Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage));
         }
 
         /// <summary>
@@ -762,9 +766,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void Verify(Expression<Action<T>> expression, Times times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify(Expression<Action<T>> expression, Times times, string failMessage)
         {
-            Mock.Verify(this, expression, times, failMessage);
+            return new VerifyResult<T>(this, Mock.Verify(this, expression, times, failMessage));
         }
 
         /// <summary>
@@ -778,9 +783,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void Verify(Expression<Action<T>> expression, Func<Times> times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify(Expression<Action<T>> expression, Func<Times> times, string failMessage)
         {
-            Mock.Verify(this, expression, times(), failMessage);
+            return new VerifyResult<T>(this, Mock.Verify(this, expression, times(), failMessage));
         }
 
         /// <summary>
@@ -802,9 +808,10 @@ namespace Moq
         ///     mock.Verify(warehouse => warehouse.HasInventory(TALISKER, 50));
         ///   </code>
         /// </example>
-        public void Verify<TResult>(Expression<Func<T, TResult>> expression)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify<TResult>(Expression<Func<T, TResult>> expression)
         {
-            Mock.Verify(this, expression, Times.AtLeastOnce(), null);
+            return new VerifyResult<T>(this, Mock.Verify(this, expression, Times.AtLeastOnce(), null));
         }
 
         /// <summary>
@@ -817,9 +824,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify<TResult>(Expression<Func<T, TResult>> expression, Times times)
         {
-            Mock.Verify(this, expression, times, null);
+            return new VerifyResult<T>(this, Mock.Verify(this, expression, times, null));
         }
 
         /// <summary>
@@ -832,9 +840,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void Verify<TResult>(Expression<Func<T, TResult>> expression, Func<Times> times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify<TResult>(Expression<Func<T, TResult>> expression, Func<Times> times)
         {
-            Mock.Verify(this, expression, times(), null);
+            return new VerifyResult<T>(this, Mock.Verify(this, expression, times(), null));
         }
 
         /// <summary>
@@ -848,9 +857,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number times specified by <paramref name="times"/>.
         /// </exception>
-        public void Verify<TResult>(Expression<Func<T, TResult>> expression, Func<Times> times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify<TResult>(Expression<Func<T, TResult>> expression, Func<Times> times, string failMessage)
         {
-            Mock.Verify(this, expression, times(), failMessage);
+            return new VerifyResult<T>(this, Mock.Verify(this, expression, times(), failMessage));
         }
 
         /// <summary>
@@ -874,9 +884,10 @@ namespace Moq
         ///                 "When filling orders, inventory has to be checked");
         ///   </code>
         /// </example>
-        public void Verify<TResult>(Expression<Func<T, TResult>> expression, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify<TResult>(Expression<Func<T, TResult>> expression, string failMessage)
         {
-            Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
+            return new VerifyResult<T>(this, Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage));
         }
 
         /// <summary>
@@ -890,9 +901,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number times specified by <paramref name="times"/>.
         /// </exception>
-        public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> Verify<TResult>(Expression<Func<T, TResult>> expression, Times times, string failMessage)
         {
-            Mock.Verify(this, expression, times, failMessage);
+            return new VerifyResult<T>(this, Mock.Verify(this, expression, times, failMessage));
         }
 
         /// <summary>
@@ -912,12 +924,13 @@ namespace Moq
         ///     ... // exercise mock
         ///
         ///     // Will throw if the test code didn't retrieve the IsClosed property.
-        ///     mock.VerifyGet(warehouse => warehouse.IsClosed);
+        ///     new VerifyResult<T>(this, mock.VerifyGet(warehouse => warehouse.IsClosed));
         ///   </code>
         /// </example>
-        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression)
         {
-            Mock.VerifyGet(this, expression, Times.AtLeastOnce(), null);
+            return new VerifyResult<T>(this, Mock.VerifyGet(this, expression, Times.AtLeastOnce(), null));
         }
 
         /// <summary>
@@ -931,9 +944,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Times times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Times times)
         {
-            Mock.VerifyGet(this, expression, times, null);
+            return new VerifyResult<T>(this, Mock.VerifyGet(this, expression, times, null));
         }
 
         /// <summary>
@@ -947,9 +961,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Func<Times> times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Func<Times> times)
         {
-            VerifyGet(this, expression, times(), null);
+            return new VerifyResult<T>(this, VerifyGet(this, expression, times(), null));
         }
 
         /// <summary>
@@ -961,9 +976,10 @@ namespace Moq
         ///   Type of the property to verify. Typically omitted as it can be inferred from the expression's return type.
         /// </typeparam>
         /// <exception cref="MockException">The invocation was not performed on the mock.</exception>
-        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, string failMessage)
         {
-            Mock.VerifyGet(this, expression, Times.AtLeastOnce(), failMessage);
+            return new VerifyResult<T>(this, Mock.VerifyGet(this, expression, Times.AtLeastOnce(), failMessage));
         }
 
         /// <summary>
@@ -978,9 +994,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Times times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Times times, string failMessage)
         {
-            Mock.VerifyGet(this, expression, times, failMessage);
+            return new VerifyResult<T>(this, Mock.VerifyGet(this, expression, times, failMessage));
         }
 
         /// <summary>
@@ -995,9 +1012,10 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Func<Times> times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Func<Times> times, string failMessage)
         {
-            VerifyGet(this, expression, times(), failMessage);
+            return new VerifyResult<T>(this, VerifyGet(this, expression, times(), failMessage));
         }
 
         /// <summary>
@@ -1014,15 +1032,16 @@ namespace Moq
         ///     ... // exercise mock
         ///
         ///     // Will throw if the test code didn't set the IsClosed property.
-        ///     mock.VerifySet(warehouse => warehouse.IsClosed = true);
+        ///     new VerifyResult<T>(this, mock.VerifySet(warehouse => warehouse.IsClosed = true));
         ///   </code>
         /// </example>
-        public void VerifySet(Action<T> setterExpression)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifySet(Action<T> setterExpression)
         {
             Guard.NotNull(setterExpression, nameof(setterExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
-            Mock.VerifySet(this, expression, Times.AtLeastOnce(), null);
+            return new VerifyResult<T>(this, Mock.VerifySet(this, expression, Times.AtLeastOnce(), null));
         }
 
         /// <summary>
@@ -1033,12 +1052,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifySet(Action<T> setterExpression, Times times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifySet(Action<T> setterExpression, Times times)
         {
             Guard.NotNull(setterExpression, nameof(setterExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
-            Mock.VerifySet(this, expression, times, null);
+            return new VerifyResult<T>(this, Mock.VerifySet(this, expression, times, null));
         }
 
         /// <summary>
@@ -1049,12 +1069,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifySet(Action<T> setterExpression, Func<Times> times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifySet(Action<T> setterExpression, Func<Times> times)
         {
             Guard.NotNull(setterExpression, nameof(setterExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
-            Mock.VerifySet(this, expression, times(), null);
+            return new VerifyResult<T>(this, Mock.VerifySet(this, expression, times(), null));
         }
 
         /// <summary>
@@ -1076,12 +1097,13 @@ namespace Moq
         ///                    "Warehouse should always be closed after the action");
         ///   </code>
         /// </example>
-        public void VerifySet(Action<T> setterExpression, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifySet(Action<T> setterExpression, string failMessage)
         {
             Guard.NotNull(setterExpression, nameof(setterExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
-            Mock.VerifySet(this, expression, Times.AtLeastOnce(), failMessage);
+            return new VerifyResult<T>(this, Mock.VerifySet(this, expression, Times.AtLeastOnce(), failMessage));
         }
 
         /// <summary>
@@ -1093,12 +1115,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifySet(Action<T> setterExpression, Times times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifySet(Action<T> setterExpression, Times times, string failMessage)
         {
             Guard.NotNull(setterExpression, nameof(setterExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
-            Mock.VerifySet(this, expression, times, failMessage);
+            return new VerifyResult<T>(this, Mock.VerifySet(this, expression, times, failMessage));
         }
 
         /// <summary>
@@ -1110,12 +1133,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifySet(Action<T> setterExpression, Func<Times> times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifySet(Action<T> setterExpression, Func<Times> times, string failMessage)
         {
             Guard.NotNull(setterExpression, nameof(setterExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
-            Mock.VerifySet(this, expression, times(), failMessage);
+            return new VerifyResult<T>(this, Mock.VerifySet(this, expression, times(), failMessage));
         }
 
         /// <summary>
@@ -1135,12 +1159,13 @@ namespace Moq
         ///     mock.VerifyAdd(warehouse => warehouse.OnClosed += It.IsAny&lt;EventHandler&gt;());
         ///   </code>
         /// </example>
-        public void VerifyAdd(Action<T> addExpression)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyAdd(Action<T> addExpression)
         {
             Guard.NotNull(addExpression, nameof(addExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
-            Mock.VerifyAdd(this, expression, Times.AtLeastOnce(), null);
+            return new VerifyResult<T>(this, Mock.VerifyAdd(this, expression, Times.AtLeastOnce(), null));
         }
 
         /// <summary>
@@ -1151,12 +1176,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyAdd(Action<T> addExpression, Times times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyAdd(Action<T> addExpression, Times times)
         {
             Guard.NotNull(addExpression, nameof(addExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
-            Mock.VerifyAdd(this, expression, times, null);
+            return new VerifyResult<T>(this, Mock.VerifyAdd(this, expression, times, null));
         }
 
         /// <summary>
@@ -1167,12 +1193,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyAdd(Action<T> addExpression, Func<Times> times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyAdd(Action<T> addExpression, Func<Times> times)
         {
             Guard.NotNull(addExpression, nameof(addExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
-            Mock.VerifyAdd(this, expression, times(), null);
+            return new VerifyResult<T>(this, Mock.VerifyAdd(this, expression, times(), null));
         }
 
         /// <summary>
@@ -1181,12 +1208,13 @@ namespace Moq
         /// <param name="addExpression">Expression to verify.</param>
         /// <param name="failMessage">Message to show if verification fails.</param>
         /// <exception cref="MockException">The invocation was not performed on the mock.</exception>
-        public void VerifyAdd(Action<T> addExpression, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyAdd(Action<T> addExpression, string failMessage)
         {
             Guard.NotNull(addExpression, nameof(addExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
-            Mock.VerifyAdd(this, expression, Times.AtLeastOnce(), failMessage);
+            return new VerifyResult<T>(this, Mock.VerifyAdd(this, expression, Times.AtLeastOnce(), failMessage));
         }
 
         /// <summary>
@@ -1198,12 +1226,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyAdd(Action<T> addExpression, Times times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyAdd(Action<T> addExpression, Times times, string failMessage)
         {
             Guard.NotNull(addExpression, nameof(addExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
-            Mock.VerifyAdd(this, expression, times, failMessage);
+            return new VerifyResult<T>(this, Mock.VerifyAdd(this, expression, times, failMessage));
         }
 
         /// <summary>
@@ -1215,12 +1244,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyAdd(Action<T> addExpression, Func<Times> times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyAdd(Action<T> addExpression, Func<Times> times, string failMessage)
         {
             Guard.NotNull(addExpression, nameof(addExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
-            Mock.VerifyAdd(this, expression, times(), failMessage);
+            return new VerifyResult<T>(this, Mock.VerifyAdd(this, expression, times(), failMessage));
         }
 
         /// <summary>
@@ -1240,12 +1270,13 @@ namespace Moq
         ///     mock.VerifyRemove(warehouse => warehouse.OnClose -= It.IsAny&lt;EventHandler&gt;());
         ///   </code>
         /// </example>
-        public void VerifyRemove(Action<T> removeExpression)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyRemove(Action<T> removeExpression)
         {
             Guard.NotNull(removeExpression, nameof(removeExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
-            Mock.VerifyRemove(this, expression, Times.AtLeastOnce(), null);
+            return new VerifyResult<T>(this, Mock.VerifyRemove(this, expression, Times.AtLeastOnce(), null));
         }
 
         /// <summary>
@@ -1256,12 +1287,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyRemove(Action<T> removeExpression, Times times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyRemove(Action<T> removeExpression, Times times)
         {
             Guard.NotNull(removeExpression, nameof(removeExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
-            Mock.VerifyRemove(this, expression, times, null);
+            return new VerifyResult<T>(this, Mock.VerifyRemove(this, expression, times, null));
         }
 
         /// <summary>
@@ -1272,12 +1304,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyRemove(Action<T> removeExpression, Func<Times> times)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyRemove(Action<T> removeExpression, Func<Times> times)
         {
             Guard.NotNull(removeExpression, nameof(removeExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
-            Mock.VerifyRemove(this, expression, times(), null);
+            return new VerifyResult<T>(this, Mock.VerifyRemove(this, expression, times(), null));
         }
 
         /// <summary>
@@ -1286,12 +1319,13 @@ namespace Moq
         /// <param name="removeExpression">Expression to verify.</param>
         /// <param name="failMessage">Message to show if verification fails.</param>
         /// <exception cref="MockException">The invocation was not performed on the mock.</exception>
-        public void VerifyRemove(Action<T> removeExpression, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyRemove(Action<T> removeExpression, string failMessage)
         {
             Guard.NotNull(removeExpression, nameof(removeExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
-            Mock.VerifyRemove(this, expression, Times.AtLeastOnce(), failMessage);
+            return new VerifyResult<T>(this, Mock.VerifyRemove(this, expression, Times.AtLeastOnce(), failMessage));
         }
 
         /// <summary>
@@ -1303,12 +1337,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyRemove(Action<T> removeExpression, Times times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyRemove(Action<T> removeExpression, Times times, string failMessage)
         {
             Guard.NotNull(removeExpression, nameof(removeExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
-            Mock.VerifyRemove(this, expression, times, failMessage);
+            return new VerifyResult<T>(this, Mock.VerifyRemove(this, expression, times, failMessage));
         }
 
         /// <summary>
@@ -1320,12 +1355,13 @@ namespace Moq
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        public void VerifyRemove(Action<T> removeExpression, Func<Times> times, string failMessage)
+        /// <returns>A list of matching invocations</returns>
+        public IVerifyResult<T> VerifyRemove(Action<T> removeExpression, Func<Times> times, string failMessage)
         {
             Guard.NotNull(removeExpression, nameof(removeExpression));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
-            Mock.VerifyRemove(this, expression, times(), failMessage);
+            return new VerifyResult<T>(this, Mock.VerifyRemove(this, expression, times(), failMessage));
         }
 
         /// <summary>

--- a/src/Moq/Protected/IProtectedAsMock.cs
+++ b/src/Moq/Protected/IProtectedAsMock.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq.Expressions;
 
@@ -115,7 +116,8 @@ namespace Moq.Protected
         /// </param>
         /// <param name="failMessage">Message to include in the thrown <see cref="MockException"/> if verification fails.</param>
         /// <exception cref="MockException">The specified invocation did not occur (or did not occur the specified number of times).</exception>
-        void Verify(Expression<Action<TAnalog>> expression, Times? times = null, string failMessage = null);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<T> Verify(Expression<Action<TAnalog>> expression, Times? times = null, string failMessage = null);
 
         /// <summary>
         /// Verifies that a specific invocation matching the given expression was performed on the mock.
@@ -129,7 +131,8 @@ namespace Moq.Protected
         /// </param>
         /// <param name="failMessage">Message to include in the thrown <see cref="MockException"/> if verification fails.</param>
         /// <exception cref="MockException">The specified invocation did not occur (or did not occur the specified number of times).</exception>
-        void Verify<TResult>(Expression<Func<TAnalog, TResult>> expression, Times? times = null, string failMessage = null);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<T> Verify<TResult>(Expression<Func<TAnalog, TResult>> expression, Times? times = null, string failMessage = null);
 
         /// <summary>
         ///   Verifies that a property was set on the mock.
@@ -143,7 +146,8 @@ namespace Moq.Protected
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        void VerifySet(Action<TAnalog> setterExpression, Times? times = null, string failMessage = null);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<T> VerifySet(Action<TAnalog> setterExpression, Times? times = null, string failMessage = null);
 
         /// <summary>
         /// Verifies that a property was read on the mock.
@@ -156,6 +160,7 @@ namespace Moq.Protected
         /// </param>
         /// <param name="failMessage">Message to include in the thrown <see cref="MockException"/> if verification fails.</param>
         /// <exception cref="MockException">The specified invocation did not occur (or did not occur the specified number of times).</exception>
-        void VerifyGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression, Times? times = null, string failMessage = null);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<T> VerifyGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression, Times? times = null, string failMessage = null);
     }
 }

--- a/src/Moq/Protected/IProtectedMock.cs
+++ b/src/Moq/Protected/IProtectedMock.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 using Moq.Language;
@@ -182,7 +183,8 @@ namespace Moq.Protected
         /// <param name="times">The number of times a method is allowed to be called.</param>
         /// <param name="args">The optional arguments for the invocation. If argument matchers are used, 
         /// remember to use <see cref="ItExpr"/> rather than <see cref="It"/>.</param>
-        void Verify(string methodName, Times times, params object[] args);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<TMock> Verify(string methodName, Times times, params object[] args);
 
         /// <summary>
         /// Specifies a verify for a void method with the given <paramref name="methodName"/>,
@@ -196,7 +198,8 @@ namespace Moq.Protected
         /// <param name="times">The number of times a method is allowed to be called.</param>
         /// <param name="args">The optional arguments for the invocation. If argument matchers are used, 
         /// remember to use <see cref="ItExpr"/> rather than <see cref="It"/>.</param>
-        void Verify(string methodName, Type[] genericTypeArguments, Times times, params object[] args);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<TMock> Verify(string methodName, Type[] genericTypeArguments, Times times, params object[] args);
 
         /// <summary>
         /// Specifies a verify for a void method with the given <paramref name="methodName"/>,
@@ -210,7 +213,8 @@ namespace Moq.Protected
         /// <param name="exactParameterMatch">Should the parameter types match exactly types that were provided</param>
         /// <param name="args">The optional arguments for the invocation. If argument matchers are used, 
         /// remember to use <see cref="ItExpr"/> rather than <see cref="It"/>.</param>
-        void Verify(string methodName, Times times, bool exactParameterMatch, params object[] args);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<TMock> Verify(string methodName, Times times, bool exactParameterMatch, params object[] args);
 
         /// <summary>
         /// Specifies a verify for a void method with the given <paramref name="methodName"/>,
@@ -225,7 +229,8 @@ namespace Moq.Protected
         /// <param name="exactParameterMatch">Should the parameter types match exactly types that were provided</param>
         /// <param name="args">The optional arguments for the invocation. If argument matchers are used, 
         /// remember to use <see cref="ItExpr"/> rather than <see cref="It"/>.</param>
-        void Verify(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<TMock> Verify(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args);
 
         /// <summary>
         /// Specifies a verify for an invocation on a property or a non void method with the given 
@@ -238,7 +243,8 @@ namespace Moq.Protected
         /// remember to use <see cref="ItExpr"/> rather than <see cref="It"/>.</param>
         /// <param name="times">The number of times a method is allowed to be called.</param>
         /// <typeparam name="TResult">The type of return value from the expression.</typeparam>
-        void Verify<TResult>(string methodName, Times times, params object[] args);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<TMock> Verify<TResult>(string methodName, Times times, params object[] args);
 
         /// <summary>
         /// Specifies a verify for an invocation on a property or a non void method with the given 
@@ -252,7 +258,8 @@ namespace Moq.Protected
         /// remember to use <see cref="ItExpr"/> rather than <see cref="It"/>.</param>
         /// <param name="times">The number of times a method is allowed to be called.</param>
         /// <typeparam name="TResult">The type of return value from the expression.</typeparam>
-        void Verify<TResult>(string methodName, Type[] genericTypeArguments, Times times, params object[] args);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<TMock> Verify<TResult>(string methodName, Type[] genericTypeArguments, Times times, params object[] args);
 
         /// <summary>
         /// Specifies a verify for an invocation on a property or a non void method with the given 
@@ -266,7 +273,8 @@ namespace Moq.Protected
         /// remember to use <see cref="ItExpr"/> rather than <see cref="It"/>.</param>
         /// <param name="times">The number of times a method is allowed to be called.</param>
         /// <typeparam name="TResult">The type of return value from the expression.</typeparam>
-        void Verify<TResult>(string methodName, Times times, bool exactParameterMatch, params object[] args);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<TMock> Verify<TResult>(string methodName, Times times, bool exactParameterMatch, params object[] args);
 
         /// <summary>
         /// Specifies a verify for an invocation on a property or a non void method with the given 
@@ -281,7 +289,8 @@ namespace Moq.Protected
         /// remember to use <see cref="ItExpr"/> rather than <see cref="It"/>.</param>
         /// <param name="times">The number of times a method is allowed to be called.</param>
         /// <typeparam name="TResult">The type of return value from the expression.</typeparam>
-        void Verify<TResult>(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args);
+        /// <returns>A list of matching invocations</returns>
+        IVerifyResult<TMock> Verify<TResult>(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args);
 
         /// <summary>
         /// Specifies a verify for an invocation on a property getter with the given 
@@ -292,8 +301,9 @@ namespace Moq.Protected
         /// <param name="propertyName">The name of the property.</param>
         /// <param name="times">The number of times a method is allowed to be called.</param>
         /// <typeparam name="TProperty">The type of the property.</typeparam>
+        /// <returns>A list of matching invocations</returns>
         // TODO should receive args to support indexers
-        void VerifyGet<TProperty>(string propertyName, Times times);
+        IVerifyResult<TMock> VerifyGet<TProperty>(string propertyName, Times times);
 
         /// <summary>
         /// Specifies a setup for an invocation on a property setter with the given 
@@ -306,8 +316,9 @@ namespace Moq.Protected
         /// <param name="value">The property value.</param>
         /// <typeparam name="TProperty">The type of the property. If argument matchers are used, 
         /// remember to use <see cref="ItExpr"/> rather than <see cref="It"/>.</typeparam>
+        /// <returns>A list of matching invocations</returns>
         // TODO should receive args to support indexers
-        void VerifySet<TProperty>(string propertyName, Times times, object value);
+        IVerifyResult<TMock> VerifySet<TProperty>(string propertyName, Times times, object value);
 
         #endregion
     }

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
@@ -153,7 +154,7 @@ namespace Moq.Protected
             return new SetupSequencePhrase(setup);
         }
 
-        public void Verify(Expression<Action<TAnalog>> expression, Times? times = null, string failMessage = null)
+        public IVerifyResult<T> Verify(Expression<Action<TAnalog>> expression, Times? times = null, string failMessage = null)
         {
             Guard.NotNull(expression, nameof(expression));
 
@@ -167,10 +168,10 @@ namespace Moq.Protected
                 throw new ArgumentException(ex.Message, nameof(expression));
             }
 
-            Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
+            return new VerifyResult<T>(this.mock, Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage));
         }
 
-        public void Verify<TResult>(Expression<Func<TAnalog, TResult>> expression, Times? times = null, string failMessage = null)
+        public IVerifyResult<T> Verify<TResult>(Expression<Func<TAnalog, TResult>> expression, Times? times = null, string failMessage = null)
         {
             Guard.NotNull(expression, nameof(expression));
 
@@ -184,18 +185,18 @@ namespace Moq.Protected
                 throw new ArgumentException(ex.Message, nameof(expression));
             }
 
-            Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
+            return new VerifyResult<T>(this.mock, Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage));
         }
 
-        public void VerifySet(Action<TAnalog> setterExpression, Times? times = null, string failMessage = null)
+        public IVerifyResult<T> VerifySet(Action<TAnalog> setterExpression, Times? times = null, string failMessage = null)
         {
             Guard.NotNull(setterExpression, nameof(setterExpression));
 
             var rewrittenExpression = ReconstructAndReplaceSetter(setterExpression);
-            Mock.VerifySet(mock, rewrittenExpression, times.HasValue ? times.Value : Times.AtLeastOnce(), failMessage);
+            return new VerifyResult<T>(mock, Mock.VerifySet(mock, rewrittenExpression, times.HasValue ? times.Value : Times.AtLeastOnce(), failMessage));
         }
 
-        public void VerifyGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression, Times? times = null, string failMessage = null)
+        public IVerifyResult<T> VerifyGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression, Times? times = null, string failMessage = null)
         {
             Guard.NotNull(expression, nameof(expression));
 
@@ -209,7 +210,7 @@ namespace Moq.Protected
                 throw new ArgumentException(ex.Message, nameof(expression));
             }
 
-            Mock.VerifyGet(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
+            return new VerifyResult<T>(this.mock, Mock.VerifyGet(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage));
         }
 
         LambdaExpression ReconstructAndReplaceSetter(Action<TAnalog> setterExpression)

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -201,29 +201,29 @@ namespace Moq.Protected
 
         #region Verify
 
-        public void Verify(string methodName, Times times, object[] args)
+        public IVerifyResult<T> Verify(string methodName, Times times, object[] args)
         {
-            this.InternalVerify(methodName, null, times, false, args);
+            return this.InternalVerify(methodName, null, times, false, args);
         }
 
-        public void Verify(string methodName, Type[] genericTypeArguments, Times times, params object[] args)
-        {
-            Guard.NotNull(genericTypeArguments, nameof(genericTypeArguments));
-            this.InternalVerify(methodName, genericTypeArguments, times, false, args);
-        }
-
-        public void Verify(string methodName, Times times, bool exactParameterMatch, object[] args)
-        {
-            this.InternalVerify(methodName, null, times, exactParameterMatch, args);
-        }
-
-        public void Verify(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
+        public IVerifyResult<T> Verify(string methodName, Type[] genericTypeArguments, Times times, params object[] args)
         {
             Guard.NotNull(genericTypeArguments, nameof(genericTypeArguments));
-            this.InternalVerify(methodName, genericTypeArguments, times, exactParameterMatch, args);
+            return this.InternalVerify(methodName, genericTypeArguments, times, false, args);
         }
 
-        void InternalVerify(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
+        public IVerifyResult<T> Verify(string methodName, Times times, bool exactParameterMatch, object[] args)
+        {
+            return this.InternalVerify(methodName, null, times, exactParameterMatch, args);
+        }
+
+        public IVerifyResult<T> Verify(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
+        {
+            Guard.NotNull(genericTypeArguments, nameof(genericTypeArguments));
+            return this.InternalVerify(methodName, genericTypeArguments, times, exactParameterMatch, args);
+        }
+
+        IVerifyResult<T> InternalVerify(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
         {
             Guard.NotNullOrEmpty(methodName, nameof(methodName));
 
@@ -231,32 +231,32 @@ namespace Moq.Protected
             ThrowIfMethodMissing(methodName, method, args);
             ThrowIfPublicMethod(method, typeof(T).Name);
 
-            Mock.Verify(mock, GetMethodCall(method, args), times, null);
+            return new VerifyResult<T>(mock, Mock.Verify(mock, GetMethodCall(method, args), times, null));
         }
 
-        public void Verify<TResult>(string methodName, Times times, object[] args)
+        public IVerifyResult<T> Verify<TResult>(string methodName, Times times, object[] args)
         {
-            this.InternalVerify<TResult>(methodName, null, times, false, args);
+            return this.InternalVerify<TResult>(methodName, null, times, false, args);
         }
 
-        public void Verify<TResult>(string methodName, Type[] genericTypeArguments, Times times, params object[] args)
-        {
-            Guard.NotNull(genericTypeArguments, nameof(genericTypeArguments));
-            this.InternalVerify<TResult>(methodName, genericTypeArguments, times, false, args);
-        }
-
-        public void Verify<TResult>(string methodName, Times times, bool exactParameterMatch, object[] args)
-        {
-            this.InternalVerify<TResult>(methodName, null, times, exactParameterMatch, args);
-        }
-
-        public void Verify<TResult>(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
+        public IVerifyResult<T> Verify<TResult>(string methodName, Type[] genericTypeArguments, Times times, params object[] args)
         {
             Guard.NotNull(genericTypeArguments, nameof(genericTypeArguments));
-            this.InternalVerify<TResult>(methodName, genericTypeArguments, times, exactParameterMatch, args);
+            return this.InternalVerify<TResult>(methodName, genericTypeArguments, times, false, args);
         }
 
-        void InternalVerify<TResult>(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
+        public IVerifyResult<T> Verify<TResult>(string methodName, Times times, bool exactParameterMatch, object[] args)
+        {
+            return this.InternalVerify<TResult>(methodName, null, times, exactParameterMatch, args);
+        }
+
+        public IVerifyResult<T> Verify<TResult>(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
+        {
+            Guard.NotNull(genericTypeArguments, nameof(genericTypeArguments));
+            return this.InternalVerify<TResult>(methodName, genericTypeArguments, times, exactParameterMatch, args);
+        }
+
+        IVerifyResult<T> InternalVerify<TResult>(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
         {
             Guard.NotNullOrEmpty(methodName, nameof(methodName));
 
@@ -265,19 +265,18 @@ namespace Moq.Protected
             {
                 ThrowIfPublicGetter(property, typeof(T).Name);
                 // TODO should consider property indexers
-                Mock.VerifyGet(mock, GetMemberAccess<TResult>(property), times, null);
-                return;
+                return new VerifyResult<T>(mock, Mock.VerifyGet(mock, GetMemberAccess<TResult>(property), times, null));
             }
 
             var method = GetMethod(methodName, genericTypeArguments, exactParameterMatch, args);
             ThrowIfMethodMissing(methodName, method, args);
             ThrowIfPublicMethod(method, typeof(T).Name);
 
-            Mock.Verify(mock, GetMethodCall<TResult>(method, args), times, null);
+            return new VerifyResult<T>(mock, Mock.Verify(mock, GetMethodCall<TResult>(method, args), times, null));
         }
 
         // TODO should receive args to support indexers
-        public void VerifyGet<TProperty>(string propertyName, Times times)
+        public IVerifyResult<T> VerifyGet<TProperty>(string propertyName, Times times)
         {
             Guard.NotNullOrEmpty(propertyName, nameof(propertyName));
 
@@ -287,11 +286,11 @@ namespace Moq.Protected
             Guard.CanRead(property);
 
             // TODO should consider property indexers
-            Mock.VerifyGet(mock, GetMemberAccess<TProperty>(property), times, null);
+            return new VerifyResult<T>(mock, Mock.VerifyGet(mock, GetMemberAccess<TProperty>(property), times, null));
         }
 
         // TODO should receive args to support indexers
-        public void VerifySet<TProperty>(string propertyName, Times times, object value)
+        public IVerifyResult<T> VerifySet<TProperty>(string propertyName, Times times, object value)
         {
             Guard.NotNullOrEmpty(propertyName, nameof(propertyName));
 
@@ -303,7 +302,7 @@ namespace Moq.Protected
             var expression = GetSetterExpression(property, ToExpressionArg(property.PropertyType, value));
             // TODO should consider property indexers
             // TODO should receive the parameter here
-            Mock.VerifySet(mock, expression, times, null);
+            return new VerifyResult<T>(mock, Mock.VerifySet(mock, expression, times, null));
         }
 
         #endregion

--- a/src/Moq/VerifyResult.cs
+++ b/src/Moq/VerifyResult.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moq
+{
+    class VerifyResult<T> : List<IInvocation>, IVerifyResult<T> where T : class
+    {
+        public Mock<T> Mock { get; }
+
+        public VerifyResult(Mock<T> mock, IEnumerable<IInvocation> invocations) : base(invocations)
+        {
+            this.Mock = mock;
+        }
+    }
+}


### PR DESCRIPTION
This is not a fully-realized API for sequence verification, but instead a minimal set of changes that exposes enough information to allow users to write their own sequence verification utilities that meet their specific needs. Existing user code can only inspect the `mock.Invocations` list for this purpose but with two major drawbacks: the order of invocations between separate mocks is unknown and filtering the list cumbersome without the expression matching functionality of `mock.Setup(...)` and `mock.Verify(...)`.
These issues are addressed as follows:
- Allow the total order of invocations to be compared between separate mocks by storing an atomically incremented global sequence number to each `Invocation`.
- Return the list of matching `Invocation`s from `mock.Verify(...)` (and all of its variations) as a convenient way of filtering the invocation list.
  - The returned list also includes the mock itself to allow for potential extension method chaining.